### PR TITLE
add autofocus to search input control

### DIFF
--- a/apps/frontend/src/frontend/view/search_input/search_input.gleam
+++ b/apps/frontend/src/frontend/view/search_input/search_input.gleam
@@ -20,6 +20,7 @@ pub fn view(loading loading: Bool, input input: String, small small: Bool) {
           a.value(input),
           a.attribute("autocorrect", "off"),
           a.attribute("autocapitalize", "none"),
+          a.attribute("autofocus", "autofocus"),
         ]),
         s.shortcut_hint([], [el.text(modifier <> " + K")]),
       ]),


### PR DESCRIPTION
I did not test this, I just skimmed through the code on github after seeing that it does not grab focus on entering the page.